### PR TITLE
Allow unknown thermostats to work instead of failing silently.

### DIFF
--- a/radiotherm/__init__.py
+++ b/radiotherm/__init__.py
@@ -18,6 +18,7 @@ def get_thermostat_class(model):
     for thermostat in THERMOSTATS:
         if issubclass(thermostat, Thermostat) and thermostat.MODEL == model:
             return thermostat
+        
     #then partial matches
     for thermostat in THERMOSTATS:
         if issubclass(thermostat, Thermostat) and model.startswith(thermostat.MODEL):


### PR DESCRIPTION
The current version fails if a thermostat model is unknown